### PR TITLE
Code Cleaning

### DIFF
--- a/src/debris/Debris.cpp
+++ b/src/debris/Debris.cpp
@@ -6,7 +6,7 @@
 namespace Debris {
 
 Debris::Debris()
-= default;
+    = default;
 
 Debris::Debris(const Debris& other)
 {
@@ -19,7 +19,8 @@ Debris::Debris(const Debris& other)
 }
 
 Debris::~Debris() = default;
-std::string Debris::toString()
+
+std::string Debris::toString() const
 {
     std::stringstream stream;
     stream << "Debris: X:" << IOUtils::to_string(position)
@@ -34,24 +35,29 @@ std::string Debris::toString()
     return stream.str();
 }
 
-double Debris::getHeight()
+double Debris::getHeight() const
 {
     return MathUtils::euclideanNorm(position);
 }
 
-double Debris::getSpeed()
+double Debris::getSpeed() const
 {
     return MathUtils::euclideanNorm(velocity);
 }
 
-double Debris::getAccT0Norm()
+double Debris::getAccT0Norm() const
 {
     return MathUtils::euclideanNorm(acc_t0);
 }
 
-double Debris::getAccT1Norm()
+double Debris::getAccT1Norm() const
 {
     return MathUtils::euclideanNorm(acc_t1);
+}
+
+const std::array<double, 3>& Debris::getPosition() const
+{
+    return position;
 }
 
 std::array<double, 3>& Debris::getPosition()
@@ -59,9 +65,14 @@ std::array<double, 3>& Debris::getPosition()
     return position;
 }
 
-void Debris::setPosition(std::array<double, 3>& position)
+void Debris::setPosition(const std::array<double, 3>& position)
 {
     Debris::position = position;
+}
+
+const std::array<double, 3>& Debris::getVelocity() const
+{
+    return velocity;
 }
 
 std::array<double, 3>& Debris::getVelocity()
@@ -69,9 +80,14 @@ std::array<double, 3>& Debris::getVelocity()
     return velocity;
 }
 
-void Debris::setVelocity(std::array<double, 3>& velocity)
+void Debris::setVelocity(const std::array<double, 3>& velocity)
 {
     Debris::velocity = velocity;
+}
+
+const std::array<double, 3>& Debris::getAccT0() const
+{
+    return acc_t0;
 }
 
 std::array<double, 3>& Debris::getAccT0()
@@ -79,9 +95,14 @@ std::array<double, 3>& Debris::getAccT0()
     return acc_t0;
 }
 
-void Debris::setAccT0(std::array<double, 3>& accT0)
+void Debris::setAccT0(const std::array<double, 3>& accT0)
 {
     acc_t0 = accT0;
+}
+
+const std::array<double, 3>& Debris::getAccT1() const
+{
+    return acc_t1;
 }
 
 std::array<double, 3>& Debris::getAccT1()
@@ -89,27 +110,27 @@ std::array<double, 3>& Debris::getAccT1()
     return acc_t1;
 }
 
-void Debris::setAccT1(std::array<double, 3>& accT1)
+void Debris::setAccT1(const std::array<double, 3>& accT1)
 {
     acc_t1 = accT1;
 }
 
-double Debris::getAom()
+double Debris::getAom() const
 {
     return aom;
 }
 
-void Debris::setAom(double aom)
+void Debris::setAom(const double aom)
 {
     Debris::aom = aom;
 }
 
-double Debris::getBcInv()
+double Debris::getBcInv() const
 {
     return bc_inv;
 }
 
-void Debris::setBcInv(double bcInv)
+void Debris::setBcInv(const double bcInv)
 {
     bc_inv = bcInv;
 }

--- a/src/debris/Debris.h
+++ b/src/debris/Debris.h
@@ -55,44 +55,44 @@ public:
      *
      * @return The string "Debris: X:#position v:#velocity a0:#acc_t0 a1:#acc_t1"
      */
-    std::string toString();
+    [[nodiscard]] std::string toString() const;
 
     /**
      * @brief Calculates distance from the origin of the coordinate frame
      *
      * @return Euclidean norm of the #position vector
      */
-    double getHeight();
+    [[nodiscard]] double getHeight() const;
 
     /**
      * @brief Calculates speed of the debris
      *
      * @return Euclidean norm of the #velocity vector
      */
-    double getSpeed();
+    [[nodiscard]] double getSpeed() const;
 
     /**
      * @brief Calculates the euclidean norm of the #acc_t0
      *
      * @return Calculates the euclidean norm of the #acc_t0
      */
-    double getAccT0Norm();
+    [[nodiscard]] double getAccT0Norm() const;
 
     /**
      * @brief Calculates the euclidean norm of the #acc_t1
      *
      * @return Calculates the euclidean norm of the #acc_t1
      */
-    double getAccT1Norm();
+    [[nodiscard]] double getAccT1Norm() const;
 
 private:
     std::array<double, 3>
-        position{}; /**< 3D vector representation of the debris position*/
+        position {}; /**< 3D vector representation of the debris position*/
     std::array<double, 3>
-        velocity{}; /**< 3D vector representation of the debris velocity*/
-    std::array<double, 3> acc_t0{}; /**< 3D vector representation of the debris
+        velocity {}; /**< 3D vector representation of the debris velocity*/
+    std::array<double, 3> acc_t0 {}; /**< 3D vector representation of the debris
                                  acceleration at the last time step*/
-    std::array<double, 3> acc_t1{}; /**< 3D vector representation of the debris
+    std::array<double, 3> acc_t1 {}; /**< 3D vector representation of the debris
                                  acceleration at the current time step*/
     double bc_inv = 0; /**< (C_cA)/m is the inverse of the ballistic coefficient. Used for Acceleration::DragComponent::apply()*/
     double aom = 0; /**< Area to mass ration*/
@@ -102,20 +102,22 @@ public:
      *
      * @return 3D vector representation of the debris #position
      */
-    std::array<double, 3>& getPosition();
+    [[nodiscard]] const std::array<double, 3>& getPosition() const;
+    std::array<double, 3>& getPosition() ;
 
     /**
      * @brief Setter function for #position vector
      *
      * @param position 3D vector representation of the debris #position
      */
-    void setPosition(std::array<double, 3>& position);
+    void setPosition(const std::array<double, 3>& position);
 
     /**
      * @brief Getter function for #velocity vector
      *
      * @return 3D vector representation of the debris #velocity
      */
+    [[nodiscard]] const std::array<double, 3>& getVelocity() const;
     std::array<double, 3>& getVelocity();
 
     /**
@@ -123,13 +125,14 @@ public:
      *
      * @param velocity 3D vector representation of the debris #velocity
      */
-    void setVelocity(std::array<double, 3>& velocity);
+    void setVelocity(const std::array<double, 3>& velocity);
 
     /**
      * @brief Getter function for #acc_t0 vector
      *
      * @return 3D vector representation of the debris #acc_t0
      */
+    [[nodiscard]] const std::array<double, 3>& getAccT0() const;
     std::array<double, 3>& getAccT0();
 
     /**
@@ -137,28 +140,29 @@ public:
      *
      * @param accT0 3D vector representation of the debris #acc_t0
      */
-    void setAccT0(std::array<double, 3>& accT0);
+    void setAccT0(const std::array<double, 3>& accT0);
 
     /**
      * @brief Getter function for #acc_t1 vector
      *
      * @return 3D vector representation of the debris #acc_t1
      */
-    std::array<double, 3>& getAccT1();
+    [[nodiscard]] const std::array<double, 3>& getAccT1() const;
+     std::array<double, 3>& getAccT1() ;
 
     /**
      * @brief Setter function for #acc_t1 vector
      *
      * @param accT1 3D vector representation of the debris #acc_t1
      */
-    void setAccT1(std::array<double, 3>& accT1);
+    void setAccT1(const std::array<double, 3>& accT1);
 
     /**
      * @brief Getter function for #aom
      *
      * @return value of #aom
      */
-    double getAom();
+    [[nodiscard]] double getAom() const;
 
     /**
      * @brief Setter function for #aom
@@ -172,7 +176,7 @@ public:
      *
      * @return Value of #bc_inv
      */
-    double getBcInv();
+    [[nodiscard]] double getBcInv() const;
 
     /**
      * @brief Setter function for #bc_inv

--- a/src/debris/DebrisContainer.cpp
+++ b/src/debris/DebrisContainer.cpp
@@ -4,11 +4,11 @@
 
 #include "DebrisContainer.h"
 namespace Debris {
-DebrisContainer::DebrisContainer() { }
+DebrisContainer::DebrisContainer() = default;
 
-DebrisContainer::~DebrisContainer() { }
+DebrisContainer::~DebrisContainer() = default;
 
-void DebrisContainer::addDebris(Debris& debris)
+void DebrisContainer::addDebris(const Debris& debris)
 {
     debris_vector.push_back(debris);
 }
@@ -25,6 +25,11 @@ void DebrisContainer::shiftAcceleration()
         d.setAccT0(d.getAccT1());
         d.setAccT1(new_acc);
     }
+}
+
+const std::vector<Debris>& DebrisContainer::getDebrisVector() const
+{
+    return debris_vector;
 }
 
 std::vector<Debris>& DebrisContainer::getDebrisVector()

--- a/src/debris/DebrisContainer.h
+++ b/src/debris/DebrisContainer.h
@@ -35,7 +35,7 @@ public:
      *
      * @param debris Reference to the Debris object to add
      */
-    void addDebris(Debris& debris);
+    void addDebris(const Debris& debris);
 
     /**
      * @brief Clear the #debris_vector
@@ -63,6 +63,7 @@ public:
      *
      * @return Value of #debris_vector
      */
+    [[nodiscard]] const std::vector<Debris>& getDebrisVector() const;
     std::vector<Debris>& getDebrisVector();
 
     /**

--- a/src/io/CommandLineInput.cpp
+++ b/src/io/CommandLineInput.cpp
@@ -9,7 +9,7 @@ CommandLineInput::CommandLineInput(int argc, char** argv)
     parseCommandLine(argc, argv);
 }
 
-CommandLineInput::~CommandLineInput() { }
+CommandLineInput::~CommandLineInput() = default;
 
 void CommandLineInput::parseCommandLine(int argc, char** argv)
 {
@@ -73,7 +73,7 @@ void CommandLineInput::parseCommandLine(int argc, char** argv)
     }
 }
 
-FileInput::Type CommandLineInput::getInputFileType()
+FileInput::Type CommandLineInput::getInputFileType() const
 {
     return input_file_type;
 }
@@ -83,7 +83,7 @@ void CommandLineInput::setInputFileType(FileInput::Type inputFileType)
     input_file_type = inputFileType;
 }
 
-FileOutput::Type CommandLineInput::getOutputFileType()
+FileOutput::Type CommandLineInput::getOutputFileType() const
 {
     return output_file_type;
 }
@@ -98,9 +98,14 @@ std::filesystem::path& CommandLineInput::getInputFilePath()
     return input_file_path;
 }
 
-void CommandLineInput::setInputFilePath(std::filesystem::path& inputFilePath)
+void CommandLineInput::setInputFilePath(const std::filesystem::path& inputFilePath)
 {
     input_file_path = inputFilePath;
+}
+
+const std::filesystem::path& CommandLineInput::getOutputFilePath() const
+{
+    return output_file_path;
 }
 
 std::filesystem::path& CommandLineInput::getOutputFilePath()
@@ -108,7 +113,7 @@ std::filesystem::path& CommandLineInput::getOutputFilePath()
     return output_file_path;
 }
 
-void CommandLineInput::setOutputFilePath(std::filesystem::path& outputFilePath)
+void CommandLineInput::setOutputFilePath(const std::filesystem::path& outputFilePath)
 {
     output_file_path = outputFilePath;
 }

--- a/src/io/CommandLineInput.h
+++ b/src/io/CommandLineInput.h
@@ -45,8 +45,8 @@ private:
 
     FileInput::Type input_file_type = FileInput::TXT; /**< Holds the type of the input file*/
     FileOutput::Type output_file_type = FileOutput::CSV; /**< Holds the type of the output file*/
-    std::filesystem::path input_file_path; /**< Path to the input file */
-    std::filesystem::path output_file_path; /**< Path to the main output file. USed to construct other output file paths */
+    std::filesystem::path input_file_path{}; /**< Path to the input file */
+    std::filesystem::path output_file_path{}; /**< Path to the main output file. USed to construct other output file paths */
 
 public:
     /**
@@ -54,7 +54,7 @@ public:
      *
      * @return Value of #input_file_type
      */
-    FileInput::Type getInputFileType();
+    [[nodiscard]] FileInput::Type getInputFileType() const;
 
     /**
      * @brief Setter function for #input_file_type
@@ -68,7 +68,7 @@ public:
      *
      * @return Value of #output_file_type
      */
-    FileOutput::Type getOutputFileType();
+    [[nodiscard]] FileOutput::Type getOutputFileType() const;
 
     /**
      * @brief Setter function for #output_file_type
@@ -89,13 +89,14 @@ public:
      *
      * @param inputFilePath New value of #input_file_path
      */
-    void setInputFilePath(std::filesystem::path& inputFilePath);
+    void setInputFilePath(const std::filesystem::path& inputFilePath);
 
     /**
      * @brief Getter function for #output_file_path
      *
      * @return Value of #output_file_path
      */
+    [[nodiscard]] const std::filesystem::path& getOutputFilePath() const;
     std::filesystem::path& getOutputFilePath();
 
     /**
@@ -103,5 +104,5 @@ public:
      *
      * @param outputFilePath New value of #output_file_path
      */
-    void setOutputFilePath(std::filesystem::path& outputFilePath);
+    void setOutputFilePath(const std::filesystem::path& outputFilePath);
 };

--- a/src/io/FileInput.cpp
+++ b/src/io/FileInput.cpp
@@ -30,8 +30,8 @@ void FileInput::setDebrisValues(Debris::Debris& d, const std::string& line)
     auto position_split_pos = line.find('|');
     auto velocity_split_pos = line.find('|', position_split_pos + 1);
     auto acc_split_pos = line.find('|', velocity_split_pos + 1);
-    auto aom_split_pos = line.find("|", acc_split_pos + 1);
-    auto bc_inv_split_pos = line.find("|", aom_split_pos + 1);
+    auto aom_split_pos = line.find('|', acc_split_pos + 1);
+    auto bc_inv_split_pos = line.find('|', aom_split_pos + 1);
     std::string position_str = line.substr(0, position_split_pos);
     std::string velocity_str = line.substr(position_split_pos + 1, velocity_split_pos);
     std::string acc_t0_str = line.substr(velocity_split_pos + 1, acc_split_pos);
@@ -120,6 +120,11 @@ void FileInput::readDebrisTXT()
     }
 }
 
+const Debris::DebrisContainer& FileInput::getDebris() const
+{
+    return *debris;
+}
+
 Debris::DebrisContainer& FileInput::getDebris()
 {
     return *debris;
@@ -130,17 +135,22 @@ void FileInput::setDebris(Debris::DebrisContainer& debris)
     FileInput::debris = &debris;
 }
 
+const std::filesystem::path& FileInput::getInputFilePath() const
+{
+    return input_file_path;
+}
+
 std::filesystem::path& FileInput::getInputFilePath()
 {
     return input_file_path;
 }
 
-void FileInput::setInputFilePath(std::filesystem::path& inputFilePath)
+void FileInput::setInputFilePath(const std::filesystem::path& inputFilePath)
 {
     input_file_path = inputFilePath;
 }
 
-FileInput::Type FileInput::getInputFileType()
+FileInput::Type FileInput::getInputFileType() const
 {
     return input_file_type;
 }
@@ -150,7 +160,7 @@ void FileInput::setInputFileType(FileInput::Type inputFileType)
     input_file_type = inputFileType;
 }
 
-double FileInput::getDeltaT()
+double FileInput::getDeltaT() const
 {
     return delta_t;
 }
@@ -160,7 +170,7 @@ void FileInput::setDeltaT(double deltaT)
     delta_t = deltaT;
 }
 
-double FileInput::getWriteDeltaT()
+double FileInput::getWriteDeltaT() const
 {
     return write_delta_t;
 }
@@ -170,7 +180,7 @@ void FileInput::setWriteDeltaT(double writeDeltaT)
     write_delta_t = writeDeltaT;
 }
 
-double FileInput::getStartT()
+double FileInput::getStartT() const
 {
     return start_t;
 }
@@ -180,7 +190,7 @@ void FileInput::setStartT(double startT)
     start_t = startT;
 }
 
-double FileInput::getEndT()
+double FileInput::getEndT() const
 {
     return end_t;
 }
@@ -190,12 +200,17 @@ void FileInput::setEndT(double endT)
     end_t = endT;
 }
 
+const std::array<bool, 8>& FileInput::getAccConfig() const
+{
+    return acc_config;
+}
+
 std::array<bool, 8>& FileInput::getAccConfig()
 {
     return acc_config;
 }
 
-void FileInput::setAccConfig(std::array<bool, 8>& accConfig)
+void FileInput::setAccConfig(const std::array<bool, 8>& accConfig)
 {
     acc_config = accConfig;
 }

--- a/src/io/FileInput.h
+++ b/src/io/FileInput.h
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <utility>
 
 #include "../debris/DebrisContainer.h"
 
@@ -41,10 +42,10 @@ public:
      * @param input_file_type_arg FileInput::Type of the input file
      */
     FileInput(Debris::DebrisContainer& debris_arg,
-        std::string input_file_path_arg,
+        std::filesystem::path input_file_path_arg,
         Type input_file_type_arg)
         : debris(&debris_arg)
-        , input_file_path(input_file_path_arg)
+        , input_file_path(std::move(input_file_path_arg))
         , input_file_type(input_file_type_arg)
     {
         readDebrisData();
@@ -148,15 +149,15 @@ private:
     void readDebrisTXT();
 
     Debris::DebrisContainer*
-        debris; /**< Reference to a Debris::DebrisContainer object to add
+        debris = nullptr; /**< Reference to a Debris::DebrisContainer object to add
              Debris::Debris objects read from the input file*/
-    std::filesystem::path input_file_path; /**< Complete name of the input file containing
+    std::filesystem::path input_file_path{}; /**< Complete name of the input file containing
                                 the file extension*/
-    Type input_file_type; /**< InputFile::Type of the input file*/
-    double delta_t; /**< Time step to use in the simulation*/
-    double start_t; /**< Start time of the simulation*/
-    double end_t; /**< End time of the simulation*/
-    double write_delta_t; /**< Time interval to write output */
+    Type input_file_type = TXT; /**< InputFile::Type of the input file*/
+    double delta_t = 0; /**< Time step to use in the simulation*/
+    double start_t = 0; /**< Start time of the simulation*/
+    double end_t = 0; /**< End time of the simulation*/
+    double write_delta_t = 0; /**< Time interval to write output */
     /**
      * @brief 8D bool vector encoding the Acceleration::AccelerationComponent to
      * apply in the simulation.
@@ -172,7 +173,7 @@ private:
      * - #Acceleration::SRP
      * - #Acceleration::DRAG
      */
-    std::array<bool, 8> acc_config;
+    std::array<bool, 8> acc_config{};
 
 public:
     /**
@@ -180,6 +181,7 @@ public:
      *
      * @return Value of #debris
      */
+    [[nodiscard]] const Debris::DebrisContainer& getDebris() const;
     Debris::DebrisContainer& getDebris();
 
     /**
@@ -194,6 +196,7 @@ public:
      *
      * @return Value of #input_file_path
      */
+    [[nodiscard]] const std::filesystem::path& getInputFilePath() const;
     std::filesystem::path& getInputFilePath();
 
     /**
@@ -201,14 +204,14 @@ public:
      *
      * @param inputFilePath New value of #input_file_path
      */
-    void setInputFilePath(std::filesystem::path& inputFilePath);
+    void setInputFilePath(const std::filesystem::path& inputFilePath);
 
     /**
      * @brief Getter function for #input_file_type
      *
      * @return Value of #input_file_type
      */
-    Type getInputFileType();
+    [[nodiscard]] Type getInputFileType() const;
 
     /**
      * @brief Setter function for #input_file_type
@@ -222,7 +225,7 @@ public:
      *
      * @return Value of #delta_t
      */
-    double getDeltaT();
+    [[nodiscard]] double getDeltaT() const;
 
     /**
      * @brief Setter function for #write_delta_t
@@ -236,7 +239,7 @@ public:
      *
      * @return Value of #write_delta_t
      */
-    double getWriteDeltaT();
+    [[nodiscard]] double getWriteDeltaT() const;
 
     /**
      * @brief Setter function for #delta_t
@@ -250,7 +253,7 @@ public:
      *
      * @return Value of #start_t
      */
-    double getStartT();
+    [[nodiscard]] double getStartT() const;
 
     /**
      * @brief Setter function for #start_t
@@ -264,7 +267,7 @@ public:
      *
      * @return Value of #end_t
      */
-    double getEndT();
+    [[nodiscard]] double getEndT() const;
 
     /**
      * @brief Setter function for #end_t
@@ -278,6 +281,7 @@ public:
      *
      * @return Value of #acc_config
      */
+    [[nodiscard]] const std::array<bool, 8>& getAccConfig() const;
     std::array<bool, 8>& getAccConfig();
 
     /**
@@ -285,5 +289,5 @@ public:
      *
      * @param accConfig New value of #acc_config
      */
-    void setAccConfig(std::array<bool, 8>& accConfig);
+    void setAccConfig(const std::array<bool, 8>& accConfig);
 };

--- a/src/io/FileOutput.cpp
+++ b/src/io/FileOutput.cpp
@@ -117,16 +117,21 @@ void FileOutput::writeAcc_start(double t)
     acc_out << t << ',';
 }
 
-void FileOutput::writeAcc_value(std::array<double, 3>& vec)
+void FileOutput::writeAcc_value(const std::array<double, 3>& vec)
 {
     IOUtils::to_ostream(vec, acc_out);
     acc_out << "," << MathUtils::euclideanNorm(vec) << ",";
 }
 
-void FileOutput::writeAcc_end(std::array<double, 3>& vec)
+void FileOutput::writeAcc_end(const std::array<double, 3>& vec)
 {
     IOUtils::to_ostream(vec, acc_out);
     acc_out << "," << MathUtils::euclideanNorm(vec) << "\n";
+}
+
+const Debris::DebrisContainer& FileOutput::getDebris() const
+{
+    return *debris;
 }
 
 Debris::DebrisContainer& FileOutput::getDebris()
@@ -139,17 +144,22 @@ void FileOutput::setDebris(Debris::DebrisContainer& debris)
     FileOutput::debris = &debris;
 }
 
+const std::filesystem::path& FileOutput::getOutputFilePath() const
+{
+    return output_file_path;
+}
+
 std::filesystem::path& FileOutput::getOutputFilePath()
 {
     return output_file_path;
 }
 
-void FileOutput::setOutputFilePath(std::filesystem::path& outputFilePath)
+void FileOutput::setOutputFilePath(const std::filesystem::path& outputFilePath)
 {
     output_file_path = outputFilePath;
 }
 
-FileOutput::Type FileOutput::getOutputFileType()
+FileOutput::Type FileOutput::getOutputFileType() const
 {
     return output_file_type;
 }
@@ -159,12 +169,17 @@ void FileOutput::setOutputFileType(FileOutput::Type outputFileType)
     output_file_type = outputFileType;
 }
 
+const std::filesystem::path& FileOutput::getAccOutputFilePath() const
+{
+    return acc_output_file_path;
+}
+
 std::filesystem::path& FileOutput::getAccOutputFilePath()
 {
     return acc_output_file_path;
 }
 
-void FileOutput::setAccOutputFilePath(std::filesystem::path& accOutputFilePath)
+void FileOutput::setAccOutputFilePath(const std::filesystem::path& accOutputFilePath)
 {
     acc_output_file_path = accOutputFilePath;
 }

--- a/src/io/FileOutput.h
+++ b/src/io/FileOutput.h
@@ -72,14 +72,14 @@ public:
      *
      * @param vec Reference to the 3D vector
      */
-    void writeAcc_value(std::array<double, 3>& vec);
+    void writeAcc_value(const std::array<double, 3>& vec);
 
     /**
      * @brief Writes the last 3D vector of a line to the output file
      *
      * @param vec Reference to the 3D vector
      */
-    void writeAcc_end(std::array<double, 3>& vec);
+    void writeAcc_end(const std::array<double, 3>& vec);
 
 private:
     /**
@@ -104,18 +104,19 @@ private:
         debris; /**< Reference to a Debris::DebrisContainer object to add
              Debris::Debris objects read from the input file*/
     std::filesystem::path output_file_path; /**< Path to the main output file*/
-    Type output_file_type; /**< FileOutput::Type of the output file*/
+    Type output_file_type = CSV; /**< FileOutput::Type of the output file*/
     std::ofstream out; /**< output file stream*/
-    double row_count; /**< keeps track of the row number for indexing the lines */
+    double row_count = 0; /**< keeps track of the row number for indexing the lines */
     std::filesystem::path acc_output_file_path; /**< Path to the acceleration output file*/
     std::ofstream acc_out; /**< output file stream for output of single acceleration components*/
-    double acc_row_count; /**< keeps track of the row number for indexing the lines of the acceleration data*/
+    double acc_row_count = 0; /**< keeps track of the row number for indexing the lines of the acceleration data*/
 public:
     /**
      * @brief Getter function for #debris
      *
      * @return Value of #debris
      */
+    const Debris::DebrisContainer& getDebris() const;
     Debris::DebrisContainer& getDebris();
 
     /**
@@ -130,6 +131,7 @@ public:
      *
      * @return Value of #output_file_path
      */
+    const std::filesystem::path& getOutputFilePath() const;
     std::filesystem::path& getOutputFilePath();
 
     /**
@@ -137,14 +139,14 @@ public:
      *
      * @param outputFilePath New value of #output_file_path
      */
-    void setOutputFilePath(std::filesystem::path& outputFilePath);
+    void setOutputFilePath(const std::filesystem::path& outputFilePath);
 
     /**
      * @brief Getter function for #output_file_type
      *
      * @return New value of #output_file_type
      */
-    Type getOutputFileType();
+    Type getOutputFileType() const;
 
     /**
      * @brief Setter function for #output_file_type
@@ -158,6 +160,7 @@ public:
       *
       * @return Value of #acc_output_file_path
       */
+    const std::filesystem::path& getAccOutputFilePath() const;
     std::filesystem::path& getAccOutputFilePath();
 
     /**
@@ -165,5 +168,5 @@ public:
      *
      * @param accOutputFilePath New value of #acc_output_file_path
      */
-    void setAccOutputFilePath(std::filesystem::path& accOutputFilePath);
+    void setAccOutputFilePath(const std::filesystem::path& accOutputFilePath);
 };

--- a/src/physics/AccelerationAccumulator.cpp
+++ b/src/physics/AccelerationAccumulator.cpp
@@ -7,9 +7,9 @@
 #include "AccelerationAccumulator.h"
 
 namespace Acceleration {
-AccelerationAccumulator::~AccelerationAccumulator() { }
+AccelerationAccumulator::~AccelerationAccumulator() = default;
 
-void AccelerationAccumulator::applyComponents()
+void AccelerationAccumulator::applyComponents() const
 {
     // will be modified by the apply functions
     std::array<double, 3> new_acc_total { 0, 0, 0 };
@@ -18,12 +18,12 @@ void AccelerationAccumulator::applyComponents()
     // are constant for this time step
     double c_term;
     double s_term;
-    std::array<double, 6> sun_params;
+    std::array<double, 6> sun_params{};
     // setup only needed for SolComponent and SRPComponent
     if (config[SOL] || config[SRP]) {
         sun_params = SolComponent::setUp(t);
     }
-    std::array<double, 6> moon_params;
+    std::array<double, 6> moon_params{};
     // setup only needed for LunComponent
     if (config[LUN]) {
         moon_params = LunComponent::setUp(t);
@@ -36,7 +36,7 @@ void AccelerationAccumulator::applyComponents()
     }
 
     debris->shiftAcceleration();
-    for (auto& d : debris->getDebrisVector()) {
+    for (auto& d : debris->getDebrisVector()){
         new_acc_total[0] = 0;
         new_acc_total[1] = 0;
         new_acc_total[2] = 0;
@@ -84,7 +84,7 @@ void AccelerationAccumulator::applyComponents()
     }
 }
 
-void AccelerationAccumulator::applyAmdWriteComponents()
+void AccelerationAccumulator::applyAmdWriteComponents() const
 {
     // will be modified by the apply functions
     std::array<double, 3> new_acc_total { 0, 0, 0 };
@@ -93,12 +93,12 @@ void AccelerationAccumulator::applyAmdWriteComponents()
     // are constant for this time step
     double c_term;
     double s_term;
-    std::array<double, 6> sun_params;
+    std::array<double, 6> sun_params{};
     // setup only needed for SolComponent and SRPComponent
     if (config[SOL] || config[SRP]) {
         sun_params = SolComponent::setUp(t);
     }
-    std::array<double, 6> moon_params;
+    std::array<double, 6> moon_params{};
     // setup only needed for LunComponent
     if (config[LUN]) {
         moon_params = LunComponent::setUp(t);
@@ -140,12 +140,10 @@ void AccelerationAccumulator::applyAmdWriteComponents()
             file_output->writeAcc_value(new_acc_component);
         }
         if (config[SOL]) {
-            std::array<double, 6> sun_params = SolComponent::setUp(t);
             SolComponent::apply(d, d_srp, sun_params, new_acc_component, new_acc_total);
             file_output->writeAcc_value(new_acc_component);
         }
         if (config[LUN]) {
-            const std::array<double, 6> moon_params = LunComponent::setUp(t);
             LunComponent::apply(d, moon_params, new_acc_component, new_acc_total);
             file_output->writeAcc_value(new_acc_component);
         }
@@ -162,14 +160,24 @@ void AccelerationAccumulator::applyAmdWriteComponents()
     }
 }
 
+const std::array<bool, 8>& AccelerationAccumulator::getConfig() const
+{
+    return config;
+}
+
 std::array<bool, 8>& AccelerationAccumulator::getConfig()
 {
     return config;
 }
 
-void AccelerationAccumulator::setConfig(std::array<bool, 8>& config)
+void AccelerationAccumulator::setConfig(const std::array<bool, 8>& config)
 {
     AccelerationAccumulator::config = config;
+}
+
+const Debris::DebrisContainer& AccelerationAccumulator::getDebris() const
+{
+    return *debris;
 }
 
 Debris::DebrisContainer& AccelerationAccumulator::getDebris()
@@ -182,7 +190,7 @@ void AccelerationAccumulator::setDebris(Debris::DebrisContainer& debris)
     AccelerationAccumulator::debris = &debris;
 }
 
-double AccelerationAccumulator::getT()
+double AccelerationAccumulator::getT() const
 {
     return t;
 }
@@ -190,6 +198,11 @@ double AccelerationAccumulator::getT()
 void AccelerationAccumulator::setT(double t)
 {
     AccelerationAccumulator::t = t;
+}
+
+const FileOutput& AccelerationAccumulator::getFileOutput() const
+{
+    return *file_output;
 }
 
 FileOutput& AccelerationAccumulator::getFileOutput()

--- a/src/physics/AccelerationAccumulator.h
+++ b/src/physics/AccelerationAccumulator.h
@@ -3,7 +3,7 @@
 //
 
 #pragma once
-#include <math.h>
+#include <cmath>
 
 #include <array>
 #include <numeric>
@@ -99,14 +99,14 @@ public:
      * - Acceleration::DragComponent::apply() if #config[Acceleration::DRAG]
      *
      */
-    void applyComponents();
+    void applyComponents() const;
 
     /**
      * @brief does the same as #applyComponents() plus output
      *
      * Calculates the needed acceleration components and writes the value for each one to a csv file
      */
-    void applyAmdWriteComponents();
+    void applyAmdWriteComponents() const;
 
 private:
     /**
@@ -124,11 +124,11 @@ private:
      * - #Acceleration::SRP
      * - #Acceleration::DRAG
      */
-    std::array<bool, 8> config;
+    std::array<bool, 8> config{};
     Debris::DebrisContainer*
         debris; /**< Reference to the Debris::DebrisContainer object holding the
              Debris::Debris objects to apply acceleration to*/
-    double t; /**< current time*/
+    double t = 0; /**< current time*/
     FileOutput* file_output; /**< used to write detailed output data during calculations */
 public:
     /**
@@ -136,20 +136,22 @@ public:
      *
      * @return Value of #config
      */
-    std::array<bool, 8>& getConfig();
+    [[nodiscard]] const std::array<bool, 8>& getConfig() const;
+    std::array<bool, 8>& getConfig() ;
 
     /**
      * @brief Setter function for #config
      *
      * @param config New value of #config
      */
-    void setConfig(std::array<bool, 8>& config);
+    void setConfig(const std::array<bool, 8>& config);
 
     /**
      * @brief Getter function for #debris
      *
      * @return Value of #debris
      */
+    [[nodiscard]] const Debris::DebrisContainer& getDebris() const;
     Debris::DebrisContainer& getDebris();
 
     /**
@@ -164,7 +166,7 @@ public:
      *
      * @return Value of #t
      */
-    double getT();
+    [[nodiscard]] double getT() const;
 
     /**
      * @brief Setter function for #t
@@ -178,6 +180,7 @@ public:
      *
      * @return Value of #file_output
      */
+    [[nodiscard]] const FileOutput& getFileOutput() const;
     FileOutput& getFileOutput();
 
     /**

--- a/src/physics/AccelerationComponents/C22Component.cpp
+++ b/src/physics/AccelerationComponents/C22Component.cpp
@@ -4,62 +4,8 @@
 
 #include "C22Component.h"
 
-namespace Acceleration {
-namespace C22Component {
+namespace Acceleration::C22Component {
     namespace {
-        inline double getFC22_x(double x, double y, double z)
-        {
-            double x2 = x * x;
-            double y2 = y * y;
-            const double n = getFactor_fst() * x * (y2 - x2);
-            // x2 = (x^2 + y^2 + z^2)
-            x2 = x2 + y2 + z * z;
-            double fst = x2;
-            // y2 = (x^2 + y^2 +z^2)^2
-            y2 = x2 * x2;
-            // x2 = (x^2 + y^2 +z^2)^3
-            x2 = x2 * y2;
-            // y2 = (x^2 + y^2 +z^2)^4
-            y2 = y2 * y2;
-            const double snd = (getFactor_snd() * x) / std::sqrt(y2 * fst);
-            fst = n / std::sqrt(y2 * x2);
-            return fst + snd;
-        }
-        inline double getFC22_y(double x, double y, double z)
-        {
-            double x2 = x * x;
-            double y2 = y * y;
-            const double n = getFactor_fst() * y * (y2 - x2);
-            // x2 = (x^2 + y^2 + z^2)
-            x2 = x2 + y2 + z * z;
-            double fst = x2;
-            // y2 = (x^2 + y^2 +z^2)^2
-            y2 = x2 * x2;
-            // x2 = (x^2 + y^2 +z^2)^3
-            x2 = x2 * y2;
-            // y2 = (x^2 + y^2 +z^2)^4
-            y2 = y2 * y2;
-            const double snd = (getFactor_snd() * y) / std::sqrt(y2 * fst);
-            fst = n / std::sqrt(y2 * x2);
-            return fst - snd;
-        }
-        inline double getFC22_z(double x, double y, double z)
-        {
-            double x2 = x * x;
-            double y2 = y * y;
-            const double n = getFactor_fst() * z * (y2 - x2);
-            // x2 = x^2 + y^2 +z^2
-            x2 = x2 + y2 + z * z;
-            // y2 = (x^2 + y^2 +z^2)^2
-            y2 = x2 * x2;
-            // x2 = (x^2 + y^2 +z^2)^3
-            x2 = x2 * y2;
-            // y2 = (x^2 + y^2 +z^2)^4
-            y2 = y2 * y2;
-            // y2 = (x^2 + y^2 +z^2)^(7/2)
-            y2 = std::sqrt(y2 * x2);
-            return n / y2;
-        }
         // Eq 13
         inline constexpr double getFactor_fst()
         {
@@ -71,7 +17,7 @@ namespace C22Component {
             return std::sqrt(15) * Physics::GM_EARTH * Physics::R_EARTH * Physics::R_EARTH * Physics::C_22;
         }
     } // namespace
-    void apply(Debris::Debris& d,
+    void apply(const Debris::Debris& d,
         double c_term,
         double s_term,
         std::array<double, 3>& acc_c22,
@@ -114,5 +60,4 @@ namespace C22Component {
         acc_total[1] += acc_c22[1];
         acc_total[2] += acc_c22[2];
     }
-} // namespace C22Component
 } // namespace Acceleration

--- a/src/physics/AccelerationComponents/C22Component.h
+++ b/src/physics/AccelerationComponents/C22Component.h
@@ -6,48 +6,8 @@
 #include "../../debris/Debris.h"
 #include "../Constants.h"
 
-namespace Acceleration {
-
-/**
- * @namespace Acceleration::C22Component
- *
- * @brief Encapsulates functionality to calculate acceleration for
- * Acceleration::C22
- *
- * <a href="Math.pdf#page=2"> math reference subsection 1.3</a> *
- */
-namespace C22Component {
+namespace Acceleration::C22Component {
     namespace {
-        /**
-         * @brief Calculate terms for the x component of C22
-         * @deprecated
-         * @param x
-         * @param y
-         * @param z
-         * @return
-         */
-        inline double getFC22_x(double x, double y, double z);
-
-        /**
-         * @brief Calculate terms for the y component of C22
-         * @deprecated
-         * @param x
-         * @param y
-         * @param z
-         * @return
-         */
-        inline double getFC22_y(double x, double y, double z);
-
-        /**
-         * @brief Calculate terms for the z component of C22
-         * @deprecated
-         * @param x
-         * @param y
-         * @param z
-         * @return
-         */
-        inline double getFC22_z(double x, double y, double z);
-
         /**
          * @brief Constant factor for the first C22 term
          *
@@ -76,10 +36,9 @@ namespace C22Component {
      * @param acc_total Reference to an 3D vector to accumulate the accelerations
      * for all applied Acceleration::AccelerationComponent.
      */
-    void apply(Debris::Debris& d,
+    void apply(const Debris::Debris& d,
         double c_term,
         double s_term,
         std::array<double, 3>& acc_c22,
         std::array<double, 3>& acc_total);
-} // namespace C22Component
 } // namespace Acceleration

--- a/src/physics/AccelerationComponents/C22S22Component.cpp
+++ b/src/physics/AccelerationComponents/C22S22Component.cpp
@@ -4,8 +4,7 @@
 
 #include "C22S22Component.h"
 
-namespace Acceleration {
-namespace C22S22Component {
+namespace Acceleration::C22S22Component {
     namespace {
         // EQ 12
         inline constexpr double getFactor()
@@ -33,7 +32,7 @@ namespace C22S22Component {
             return getFactorS22_snd() * -5;
         }
     } // namespace
-    void apply(Debris::Debris& d,
+    void apply(const Debris::Debris& d,
         double c_term,
         double s_term,
         std::array<double, 3>& acc_c22s22,
@@ -81,5 +80,4 @@ namespace C22S22Component {
         acc_total[1] += acc_c22s22[1];
         acc_total[2] += acc_c22s22[2];
     }
-} // namespace C22S22Component
 } // namespace Acceleration

--- a/src/physics/AccelerationComponents/C22S22Component.h
+++ b/src/physics/AccelerationComponents/C22S22Component.h
@@ -6,21 +6,7 @@
 #include "../../debris/Debris.h"
 #include "../Constants.h"
 
-namespace Acceleration {
-
-/**
- * @namespace Acceleration::C22S22Component
- *
- * @brief Encapsulates functionality to calculate acceleration for
- * Acceleration::C22 and Acceleration::S22 at once
- *
- * Encapsulates functionality to calculate acceleration for Acceleration::C22
- * and Acceleration::S22 at once, because many terms are shared between the two
- * calculations. If both Components are both set active use this.
- *
- * <a href="Math.pdf#page=2"> math reference subsection 1.3</a>
- */
-namespace C22S22Component {
+namespace Acceleration::C22S22Component {
     namespace {
         /**
          * @brief  Calculates factor of the calculations consisting only on constants
@@ -75,10 +61,9 @@ namespace C22S22Component {
      * @param acc_total Reference to an 3D vector to accumulate the accelerations
      * for all applied Acceleration::AccelerationComponent.
      */
-    void apply(Debris::Debris& d,
+    void apply(const Debris::Debris& d,
         double c_term,
         double s_term,
         std::array<double, 3>& acc_c22s22,
         std::array<double, 3>& acc_total);
-} // namespace C22S22Component
 } // namespace Acceleration

--- a/src/physics/AccelerationComponents/DragComponent.cpp
+++ b/src/physics/AccelerationComponents/DragComponent.cpp
@@ -4,11 +4,10 @@
 
 #include "DragComponent.h"
 
-namespace Acceleration {
-namespace DragComponent {
+namespace Acceleration::DragComponent {
     namespace {
     }
-    void apply(Debris::Debris& d,
+    void apply(const Debris::Debris& d,
         std::array<double, 3>& acc_drag,
         std::array<double, 3>& acc_total)
     {
@@ -28,5 +27,4 @@ namespace DragComponent {
         acc_total[1] += acc_drag[1];
         acc_total[2] += acc_drag[2];
     }
-} // namespace DragComponent
 } // namespace Acceleration

--- a/src/physics/AccelerationComponents/DragComponent.h
+++ b/src/physics/AccelerationComponents/DragComponent.h
@@ -6,17 +6,7 @@
 #include "../../debris/Debris.h"
 #include "../Constants.h"
 
-namespace Acceleration {
-
-/**
- * @namespace Acceleration::DragComponent
- *
- * @brief Encapsulates functionality to calculate acceleration for
- * Acceleration::DRAG
- *
- * <a href="Math.pdf#page=8"> math reference subsection 1.8</a>
- */
-namespace DragComponent {
+namespace Acceleration::DragComponent {
     namespace {
     }
     /**
@@ -29,8 +19,7 @@ namespace DragComponent {
      * @param acc_total Reference to an 3D vector to accumulate the accelerations
      * for all applied Acceleration::AccelerationComponent.
      */
-    void apply(Debris::Debris& d,
+    void apply(const Debris::Debris& d,
         std::array<double, 3>& acc_drag,
         std::array<double, 3>& acc_total);
-} // namespace DragComponent
 } // namespace Acceleration

--- a/src/physics/AccelerationComponents/J2Component.cpp
+++ b/src/physics/AccelerationComponents/J2Component.cpp
@@ -4,16 +4,15 @@
 
 #include "J2Component.h"
 
-namespace Acceleration {
-namespace J2Component {
+namespace Acceleration::J2Component {
     namespace {
         // Eq 6
-        inline const double getFactor_fst()
+        inline constexpr double getFactor_fst()
         {
-            return 0.5 * Physics::GM_EARTH * Physics::R_EARTH * Physics::R_EARTH * std::sqrt(5.0) * Physics::C_20;
+            return 0.5 * Physics::GM_EARTH * Physics::R_EARTH * Physics::R_EARTH * std::sqrt(5) * Physics::C_20;
         }
     } // namespace
-    void apply(Debris::Debris& d,
+    void apply(const Debris::Debris& d,
         std::array<double, 3>& acc_j2,
         std::array<double, 3>& acc_total)
     {
@@ -36,5 +35,4 @@ namespace J2Component {
         acc_total[1] += acc_j2[1];
         acc_total[2] += acc_j2[2];
     }
-} // namespace J2Component
 } // namespace Acceleration

--- a/src/physics/AccelerationComponents/J2Component.h
+++ b/src/physics/AccelerationComponents/J2Component.h
@@ -6,26 +6,15 @@
 #include "../../debris/Debris.h"
 #include "../Constants.h"
 
-namespace Acceleration {
-
-/**
- * @namespace Acceleration::J2Component
- *
- * @brief Encapsulates functionality to calculate acceleration for
- * Acceleration::J2
- *
- * <a href="Math.pdf#page=2"> math reference subsection 1.2</a>
- */
-namespace J2Component {
+namespace Acceleration::J2Component {
     namespace {
-
         /**
          * @brief Constant factor for the first J2 term
          *
          * @return
          * (std::sqrt(5)*Physics::GM_EARTH*Physics::R_EARTH*Physics::R_EARTH*Physics::C20)/2
          */
-        inline const double getFactor_fst();
+        inline constexpr double getFactor_fst();
     } // namespace
     /**
      * @brief Calculates acceleration due to earth gravity. Taking in account the
@@ -37,8 +26,7 @@ namespace J2Component {
      * @param acc_total Reference to an 3D vector to accumulate the accelerations
      * for all applied Acceleration::AccelerationComponent.
      */
-    void apply(Debris::Debris& d,
+    void apply(const Debris::Debris& d,
         std::array<double, 3>& acc_j2,
         std::array<double, 3>& acc_total);
-} // namespace J2Component
 } // namespace Acceleration

--- a/src/physics/AccelerationComponents/KepComponent.cpp
+++ b/src/physics/AccelerationComponents/KepComponent.cpp
@@ -4,9 +4,8 @@
 
 #include "KepComponent.h"
 
-namespace Acceleration {
-namespace KepComponent {
-    void apply(Debris::Debris& d,
+namespace Acceleration::KepComponent {
+    void apply(const Debris::Debris& d,
         std::array<double, 3>& acc_kep,
         std::array<double, 3>& acc_total)
     {
@@ -26,5 +25,4 @@ namespace KepComponent {
         acc_total[1] += acc_kep[1];
         acc_total[2] += acc_kep[2];
     }
-} // namespace KepComponent
 } // namespace Acceleration

--- a/src/physics/AccelerationComponents/KepComponent.h
+++ b/src/physics/AccelerationComponents/KepComponent.h
@@ -6,17 +6,7 @@
 #include "../../debris/Debris.h"
 #include "../Constants.h"
 
-namespace Acceleration {
-
-/**
- * @namespace Acceleration::KepComponent
- *
- * @brief Encapsulates functionality to calculate acceleration for
- * Acceleration::KEP
- *
- * <a href="Math.pdf#page=1"> math reference subsection 1.1</a>
- */
-namespace KepComponent {
+namespace Acceleration::KepComponent {
     /**
      * @brief Calculates acceleration due to earth gravity. Assuming the earth as a
      * point mass
@@ -27,8 +17,7 @@ namespace KepComponent {
      * @param acc_total Reference to an 3D vector to accumulate the accelerations
      * for all applied Acceleration::AccelerationComponent.
      */
-    void apply(Debris::Debris& d,
+    void apply(const Debris::Debris& d,
         std::array<double, 3>& acc_kep,
         std::array<double, 3>& acc_total);
-} // namespace KepComponent
 } // namespace Acceleration

--- a/src/physics/AccelerationComponents/LunComponent.cpp
+++ b/src/physics/AccelerationComponents/LunComponent.cpp
@@ -4,9 +4,8 @@
 
 #include "LunComponent.h"
 
-namespace Acceleration {
-namespace LunComponent {
-    const std::array<double, 6> setUp(double t)
+namespace Acceleration::LunComponent {
+    std::array<double, 6> setUp(double t)
     {
         // Eq 37
         const double phi_m = Physics::NU_SUN * t;
@@ -66,7 +65,7 @@ namespace LunComponent {
         // all the sin and cos terms have similar in [-1,1], so multiply them before
         // multiplying BIG r_m value of ~380000
         // Eq 47
-        std::array<double, 3> moon_pos;
+        std::array<double, 3> moon_pos{};
         double c_term = std::cos(lambda_m * Physics::RAD_FACTOR);
         double s_term = std::sin(lambda_m * Physics::RAD_FACTOR);
         moon_pos[0] = c_term;
@@ -105,7 +104,7 @@ namespace LunComponent {
         moon_params[5] = moon_params[2] * d2;
         return moon_params;
     }
-    void apply(Debris::Debris& d,
+    void apply(const Debris::Debris& d,
         const std::array<double, 6>& moon_params,
         std::array<double, 3>& acc_lun,
         std::array<double, 3>& acc_total)
@@ -125,5 +124,4 @@ namespace LunComponent {
         acc_total[1] += acc_lun[1];
         acc_total[2] += acc_lun[2];
     }
-} // namespace LunComponent
 } // namespace Acceleration

--- a/src/physics/AccelerationComponents/LunComponent.h
+++ b/src/physics/AccelerationComponents/LunComponent.h
@@ -6,16 +6,7 @@
 #include "../../debris/Debris.h"
 #include "../Constants.h"
 
-namespace Acceleration {
-/**
- * @namespace Acceleration::LunComponent
- *
- * @brief Encapsulates functionality to calculate acceleration for
- * Acceleration::LUN
- *
- * <a href="Math.pdf#page=5"> math reference subsection 1.5</a>
- */
-namespace LunComponent {
+namespace Acceleration::LunComponent {
     /**
      * @brief Precalculates values needed for Acceleration::LunComponent::apply()
      *
@@ -25,7 +16,7 @@ namespace LunComponent {
      * @return 6D vector
      * [X_moon,Y_moon,Z_moon,X_moon/||POS_moon||,Y_moon/||POS_moon||,Z_moon/||POS_moon||]
      */
-    const std::array<double, 6> setUp(double t);
+    std::array<double, 6> setUp(double t);
     /**
      * @brief Calculates acceleration due to tidal forces caused by the moon
      *
@@ -37,9 +28,8 @@ namespace LunComponent {
      * @param acc_total Reference to an 3D vector to accumulate the accelerations
      * for all applied Acceleration::AccelerationComponent.
      */
-    void apply(Debris::Debris& d,
+    void apply(const Debris::Debris& d,
         const std::array<double, 6>& moon_params,
         std::array<double, 3>& acc_lun,
         std::array<double, 3>& acc_total);
-} // namespace LunComponent
 } // namespace Acceleration

--- a/src/physics/AccelerationComponents/S22Component.cpp
+++ b/src/physics/AccelerationComponents/S22Component.cpp
@@ -4,60 +4,8 @@
 
 #include "S22Component.h"
 
-namespace Acceleration {
-namespace S22Component {
+namespace Acceleration::S22Component {
     namespace {
-        inline double getFS22_x(double x, double y, double z)
-        {
-            double x2 = x * x;
-            double y2 = y * y;
-            const double n = getFactor_fst() * x2 * y;
-            // x2 = (x^2 + y^2 + z^2)
-            x2 = x2 + y2 + z * z;
-            double fst = x2;
-            // y2 = (x^2 + y^2 +z^2)^2
-            y2 = x2 * x2;
-            // x2 = (x^2 + y^2 +z^2)^3
-            x2 = x2 * y2;
-            // y2 = (x^2 + y^2 +z^2)^4
-            y2 = y2 * y2;
-            const double snd = (getFactor_snd() * y) / std::sqrt(y2 * fst);
-            fst = n / std::sqrt(y2 * x2);
-            return fst + snd;
-        }
-        inline double getFS22_y(double x, double y, double z)
-        {
-            double x2 = x * x;
-            double y2 = y * y;
-            const double n = getFactor_fst() * x * y2;
-            // x2 = (x^2 + y^2 + z^2)
-            x2 = x2 + y2 + z * z;
-            double fst = x2;
-            // y2 = (x^2 + y^2 +z^2)^2
-            y2 = x2 * x2;
-            // x2 = (x^2 + y^2 +z^2)^3
-            x2 = x2 * y2;
-            // y2 = (x^2 + y^2 +z^2)^4
-            y2 = y2 * y2;
-            const double snd = (getFactor_snd() * x) / std::sqrt(y2 * fst);
-            fst = n / std::sqrt(y2 * x2);
-            return fst + snd;
-        }
-        inline double getFS22_z(double x, double y, double z)
-        {
-            const double n = getFactor_fst() * x * y * z;
-            // x2 = x^2 + y^2 +z^2
-            double x2 = x * x + y * y + z * z;
-            // y2 = (x^2 + y^2 +z^2)^2
-            double y2 = x2 * x2;
-            // x2 = (x^2 + y^2 +z^2)^3
-            x2 = x2 * y2;
-            // y2 = (x^2 + y^2 +z^2)^4
-            y2 = y2 * y2;
-            // y2 = (x^2 + y^2 +z^2)^(7/2)
-            y2 = std::sqrt(y2 * x2);
-            return n / y2;
-        }
         // Eq 14
         inline constexpr double getFactor_fst()
         {
@@ -69,7 +17,7 @@ namespace S22Component {
             return std::sqrt(15) * Physics::GM_EARTH * Physics::R_EARTH * Physics::R_EARTH * Physics::S_22;
         }
     } // namespace
-    void apply(Debris::Debris& d,
+    void apply(const Debris::Debris& d,
         double c_term,
         double s_term,
         std::array<double, 3>& acc_s22,
@@ -106,5 +54,4 @@ namespace S22Component {
         acc_total[1] += acc_s22[1];
         acc_total[2] += acc_s22[2];
     }
-} // namespace S22Component
 } // namespace Acceleration

--- a/src/physics/AccelerationComponents/S22Component.h
+++ b/src/physics/AccelerationComponents/S22Component.h
@@ -6,46 +6,8 @@
 #include "../../debris/Debris.h"
 #include "../Constants.h"
 
-namespace Acceleration {
-
-/**
- * @namespace Acceleration::S22Component
- *
- * @brief Encapsulates functionality to calculate acceleration for
- * Acceleration::S22
- *
- * <a href="Math.pdf#page=3"> math reference subsection 1.3</a>
- */
-namespace S22Component {
+namespace Acceleration::S22Component {
     namespace {
-        /**
-         * @brief Calculate terms for the x component of S22
-         * @deprecated
-         * @param x
-         * @param y
-         * @param z
-         * @return
-         */
-        inline double getFS22_x(double x, double y, double z);
-        /**
-         * @brief Calculate terms for the y component of S22
-         * @deprecated
-         * @param x
-         * @param y
-         * @param z
-         * @return
-         */
-        inline double getFS22_y(double x, double y, double z);
-        /**
-         * @brief Calculate terms for the z component of S22
-         * @deprecated
-         * @param x
-         * @param y
-         * @param z
-         * @return
-         */
-        inline double getFS22_z(double x, double y, double z);
-
         /**
          * @brief Constant factor for the first S22 term
          *
@@ -74,10 +36,9 @@ namespace S22Component {
      * @param acc_total Reference to an 3D vector to accumulate the accelerations
      * for all applied Acceleration::AccelerationComponent.
      */
-    void apply(Debris::Debris& d,
+    void apply(const Debris::Debris& d,
         double c_term,
         double s_term,
         std::array<double, 3>& acc_s22,
         std::array<double, 3>& acc_total);
-} // namespace S22Component
 } // namespace Acceleration

--- a/src/physics/AccelerationComponents/SRPComponent.cpp
+++ b/src/physics/AccelerationComponents/SRPComponent.cpp
@@ -4,23 +4,22 @@
 
 #include "SRPComponent.h"
 
-namespace Acceleration {
-namespace SRPComponent {
+namespace Acceleration::SRPComponent {
     namespace {
         inline constexpr double getFactor()
         {
             return Physics::P_SRP * Physics::AU * Physics::AU;
         }
     }
-    const std::array<double, 6> setUp(double t)
+    std::array<double, 6> setUp(double t)
     {
         // calculation are the same as in the SolComponent setUp() function
         return Acceleration::SolComponent::setUp(t);
     }
 
-    void apply(Debris::Debris& d,
+    void apply(const Debris::Debris& d,
         double d_srp,
-        std::array<double, 6>& sun_params,
+        const std::array<double, 6>& sun_params,
         std::array<double, 3>& acc_srp,
         std::array<double, 3>& acc_total)
     {
@@ -34,12 +33,11 @@ namespace SRPComponent {
             d_srp = 1 / std::sqrt(d_srp * d_srp * d_srp);
         }
         // Eq 50
-        acc_srp[0] = d.getAom() * (acc_srp[0] * d_srp);
-        acc_srp[1] = d.getAom() * (acc_srp[1] * d_srp);
-        acc_srp[2] = d.getAom() * (acc_srp[2] * d_srp);
+        acc_srp[0] = d.getAom() * (getFactor()*d_srp*acc_srp[0]);
+        acc_srp[1] = d.getAom() * (getFactor()*d_srp*acc_srp[1]);
+        acc_srp[2] = d.getAom() * (getFactor()*d_srp*acc_srp[2]);
         acc_total[0] += acc_srp[0];
         acc_total[1] += acc_srp[1];
         acc_total[2] += acc_srp[2];
     }
-} // namespace SRPComponent
 } // namespace Acceleration

--- a/src/physics/AccelerationComponents/SRPComponent.h
+++ b/src/physics/AccelerationComponents/SRPComponent.h
@@ -7,17 +7,7 @@
 #include "../Constants.h"
 #include "SolComponent.h"
 
-namespace Acceleration {
-
-/**
- * @namespace Acceleration::SRPComponent
- *
- * @brief Encapsulates functionality to calculate acceleration for
- * Acceleration::SRP
- *
- * <a href="Math.pdf#page=2"> math reference subsection 1.3</a> *
- */
-namespace SRPComponent {
+namespace Acceleration::SRPComponent {
     namespace {
         /**
          * @brief Constant factor
@@ -35,7 +25,7 @@ namespace SRPComponent {
      * @return 6D vector
      * [X_sun,Y_sun,Z_sun,X_sun/||POS_sunY||,Y_sun/||POS_sun||,Z_sun/||POS_sun||]
      */
-    const std::array<double, 6> setUp(double t);
+    std::array<double, 6> setUp(double t);
 
     /**
      * @brief Calculates acceleration due to pressure of the suns radiation
@@ -49,10 +39,9 @@ namespace SRPComponent {
      * @param acc_total Reference to an 3D vector to accumulate the accelerations
      * for all applied Acceleration::AccelerationComponent.
      */
-    void apply(Debris::Debris& d,
+    void apply(const Debris::Debris& d,
         double d_srp,
-        std::array<double, 6>& sun_params,
+        const std::array<double, 6>& sun_params,
         std::array<double, 3>& acc_srp,
         std::array<double, 3>& acc_total);
-} // namespace SRPComponent
 } // namespace Acceleration

--- a/src/physics/AccelerationComponents/SolComponent.cpp
+++ b/src/physics/AccelerationComponents/SolComponent.cpp
@@ -4,9 +4,8 @@
 
 #include "SolComponent.h"
 
-namespace Acceleration {
-namespace SolComponent {
-    const std::array<double, 6> setUp(double t)
+namespace Acceleration::SolComponent {
+    std::array<double, 6> setUp(double t)
     {
         // Eq 24
         const double l = Physics::PHI_SUN_0 + Physics::NU_SUN * t;
@@ -38,7 +37,7 @@ namespace SolComponent {
         return sun_params;
     }
 
-    void apply(Debris::Debris& d,
+    void apply(const Debris::Debris& d,
         double& d_ref,
         const std::array<double, 6>& sun_params,
         std::array<double, 3>& acc_sol,
@@ -59,5 +58,4 @@ namespace SolComponent {
         acc_total[1] += acc_sol[1];
         acc_total[2] += acc_sol[2];
     }
-} // namespace SolComponent
 } // namespace Acceleration

--- a/src/physics/AccelerationComponents/SolComponent.h
+++ b/src/physics/AccelerationComponents/SolComponent.h
@@ -6,17 +6,7 @@
 #include "../../debris/Debris.h"
 #include "../Constants.h"
 
-namespace Acceleration {
-
-/**
- * @namespace Acceleration::SolComponent
- *
- * @brief Encapsulates functionality to calculate acceleration for
- * Acceleration::SOL
- *
- * <a href="Math.pdf#page=4"> math reference subsection 1.4</a>
- */
-namespace SolComponent {
+namespace Acceleration::SolComponent {
     /**
      * @brief Precalculates values needed for Acceleration::SolComponent::apply()
      *
@@ -26,7 +16,7 @@ namespace SolComponent {
      * @return 6D vector
      * [X_sun,Y_sun,Z_sun,X_sun/||POS_sunY||,Y_sun/||POS_sun||,Z_sun/||POS_sun||]
      */
-    const std::array<double, 6> setUp(double t);
+    std::array<double, 6> setUp(double t);
     /**
      * @brief Calculates acceleration due to tidal forces caused by the sun
      *
@@ -39,10 +29,9 @@ namespace SolComponent {
      * @param acc_total Reference to an 3D vector to accumulate the accelerations
      * for all applied Acceleration::AccelerationComponent.
      */
-    void apply(Debris::Debris& d,
+    void apply(const Debris::Debris& d,
         double& d_ref,
         const std::array<double, 6>& sun_params,
         std::array<double, 3>& acc_sol,
         std::array<double, 3>& acc_total);
-} // namespace SolComponent
 } // namespace Acceleration

--- a/src/physics/Integrator.cpp
+++ b/src/physics/Integrator.cpp
@@ -4,21 +4,21 @@
 
 #include "Integrator.h"
 
-Integrator::~Integrator() { }
+Integrator::~Integrator() = default;
 
-void Integrator::integrate(bool write_time_step)
+void Integrator::integrate(bool write_time_step) const
 {
     calculateAcceleration(write_time_step);
     calculatePosition();
     calculateVelocity();
     // update time
-    accumulator.setT(accumulator.getT() + delta_t);
+    accumulator->setT(accumulator->getT() + delta_t);
 }
 
-void Integrator::calculatePosition()
+void Integrator::calculatePosition() const
 {
     double factor = delta_t * delta_t * 0.5;
-    std::array<double, 3> new_pos;
+    std::array<double, 3> new_pos{};
     for (auto& d : debris->getDebrisVector()) {
         new_pos = d.getPosition();
         new_pos[0] = new_pos[0] + delta_t * d.getVelocity()[0] + factor * d.getAccT0()[0];
@@ -28,10 +28,10 @@ void Integrator::calculatePosition()
     }
 }
 
-void Integrator::calculateVelocity()
+void Integrator::calculateVelocity() const
 {
-    double factor = delta_t * 0.5;
-    std::array<double, 3> new_velocity;
+    const double factor = delta_t * 0.5;
+    std::array<double, 3> new_velocity{};
     for (auto& d : debris->getDebrisVector()) {
         new_velocity = d.getVelocity();
         new_velocity[0] = new_velocity[0] + factor * (d.getAccT0()[0] + d.getAccT1()[0]);
@@ -41,16 +41,16 @@ void Integrator::calculateVelocity()
     }
 }
 
-void Integrator::calculateAcceleration(bool write_time_step)
+void Integrator::calculateAcceleration(bool write_time_step) const
 {
     if (write_time_step) {
-        accumulator.applyAmdWriteComponents();
+        accumulator->applyAmdWriteComponents();
     } else {
-        accumulator.applyComponents();
+        accumulator->applyComponents();
     }
 }
 
-double Integrator::getDeltaT()
+double Integrator::getDeltaT() const
 {
     return delta_t;
 }
@@ -58,6 +58,11 @@ double Integrator::getDeltaT()
 void Integrator::setDeltaT(double deltaT)
 {
     delta_t = deltaT;
+}
+
+const Debris::DebrisContainer& Integrator::getDebris() const
+{
+    return *debris;
 }
 
 Debris::DebrisContainer& Integrator::getDebris()
@@ -70,13 +75,17 @@ void Integrator::setDebris(Debris::DebrisContainer& debris)
     Integrator::debris = &debris;
 }
 
-Acceleration::AccelerationAccumulator& Integrator::getAccumulator()
+const Acceleration::AccelerationAccumulator& Integrator::getAccumulator() const
 {
-    return accumulator;
+    return *accumulator;
 }
 
-void Integrator::setAccumulator(
-    Acceleration::AccelerationAccumulator& accumulator)
+Acceleration::AccelerationAccumulator& Integrator::getAccumulator()
 {
-    Integrator::accumulator = accumulator;
+    return *accumulator;
+}
+
+void Integrator::setAccumulator(Acceleration::AccelerationAccumulator& accumulator)
+{
+    Integrator::accumulator = &accumulator;
 }

--- a/src/physics/Integrator.h
+++ b/src/physics/Integrator.h
@@ -28,7 +28,7 @@ public:
         Acceleration::AccelerationAccumulator& accumulator_arg,
         double delta_t_arg)
         : debris(&debris_arg)
-        , accumulator(accumulator_arg)
+        , accumulator(&accumulator_arg)
         , delta_t(delta_t_arg) {};
 
     /**
@@ -49,7 +49,7 @@ public:
      *
      * @param write_time_step if true all calculated acceleration components are writen to a file
      */
-    void integrate(bool write_time_step = false);
+    void integrate(bool write_time_step = false) const;
 
     /**
      * @brief Calculates the new position
@@ -59,7 +59,7 @@ public:
      * with Debris::Debris::velocity and Debris::Debris::acc_t0
      *
      */
-    void calculatePosition();
+    void calculatePosition() const;
 
     /**
      * @brief Calculates the new velocities
@@ -69,7 +69,7 @@ public:
      * with Debris::Debris::acc_t0 and Debris::Debris::acc_t1
      *
      */
-    void calculateVelocity();
+    void calculateVelocity() const;
 
     /**
      * @brief Calculates te acceleration for the current time step
@@ -81,24 +81,24 @@ public:
      *
      * @param write_time_step if true all calculated acceleration components are writen to a file
      */
-    void calculateAcceleration(bool write_time_step);
+    void calculateAcceleration(bool write_time_step) const;
 
 private:
     Debris::DebrisContainer*
-        debris; /**< Reference to the Debris::DebrisContainer object holding the
+        debris = nullptr; /**< Reference to the Debris::DebrisContainer object holding the
              Debris::Debris objects to integrate for*/
-    Acceleration::AccelerationAccumulator&
-        accumulator; /**< Reference to the Acceleration::AccelerationAccumulator
+    Acceleration::AccelerationAccumulator*
+        accumulator = nullptr; /**< Reference to the Acceleration::AccelerationAccumulator
                    object to calculate acceleration for the current time
                    step*/
-    double delta_t; /**< Time step to Integrate over */
+    double delta_t = 0; /**< Time step to Integrate over */
 public:
     /**
      * @brief Getter function for #delta_t
      *
      * @return Value of #delta_t
      */
-    double getDeltaT();
+    [[nodiscard]] double getDeltaT() const;
 
     /**
      * @brief Setter function for #delta_t
@@ -112,6 +112,7 @@ public:
      *
      * @return Value of #accumulator
      */
+    [[nodiscard]] const Acceleration::AccelerationAccumulator& getAccumulator() const;
     Acceleration::AccelerationAccumulator& getAccumulator();
 
     /**
@@ -126,6 +127,7 @@ public:
      *
      * @return Value of #debris
      */
+    [[nodiscard]] const Debris::DebrisContainer& getDebris() const;
     Debris::DebrisContainer& getDebris();
 
     /**

--- a/src/utils/MathUtils.h
+++ b/src/utils/MathUtils.h
@@ -3,7 +3,7 @@
 //
 
 #include <array>
-#include <math.h>
+#include <cmath>
 #include <numeric>
 
 namespace MathUtils {

--- a/test/physics_test/Acceleration_test.cpp
+++ b/test/physics_test/Acceleration_test.cpp
@@ -11,7 +11,7 @@
  */
 TEST_F(KepComponentTests, RadialSymmetryTest)
 {
-    std::array<std::array<double, 3>, 8> accelerations;
+    std::array<std::array<double, 3>, 8> accelerations{};
     for (auto& acc : accelerations) {
         acc[0] = 0;
         acc[1] = 0;
@@ -71,9 +71,9 @@ TEST_F(KepComponentTests, RadialSymmetryTest)
 TEST_F(KepComponentTests, CalculationEquivalenceTest)
 {
     const int num_debris = 15;
-    std::array<std::array<double, 3>, num_debris> accelerations_1;
-    std::array<std::array<double, 3>, num_debris> accelerations_2;
-    std::array<double, 3> acc_total_dummy;
+    std::array<std::array<double, 3>, num_debris> accelerations_1{};
+    std::array<std::array<double, 3>, num_debris> accelerations_2{};
+    std::array<double, 3> acc_total_dummy{};
 
     // calculate the acceleration for all particles using two different functions
     for (int i = 0; i < num_debris; ++i) {
@@ -99,8 +99,8 @@ TEST_F(KepComponentTests, CalculationEquivalenceTest)
 TEST_F(KepComponentTests, EquilavelnceWIthPreCalculatedTest)
 {
     const int num_debris = 9;
-    std::array<std::array<double, 3>, num_debris> accelerations;
-    std::array<double, 3> acc_total_dummy;
+    std::array<std::array<double, 3>, num_debris> accelerations{};
+    std::array<double, 3> acc_total_dummy{};
 
     // calculate the acceleration for all particles using two different functions
     for (int i = 6; i < 6 + num_debris; ++i) {
@@ -125,9 +125,9 @@ TEST_F(KepComponentTests, EquilavelnceWIthPreCalculatedTest)
 TEST_F(J2ComponentTests, CalculationEquivalenceTest)
 {
     const int num_debris = 9;
-    std::array<std::array<double, 3>, num_debris> accelerations_1;
-    std::array<std::array<double, 3>, num_debris> accelerations_2;
-    std::array<double, 3> acc_total_dummy;
+    std::array<std::array<double, 3>, num_debris> accelerations_1{};
+    std::array<std::array<double, 3>, num_debris> accelerations_2{};
+    std::array<double, 3> acc_total_dummy{};
 
     // calculate the acceleration for all particles using two different functions
     for (int i = 0; i < num_debris; ++i) {
@@ -153,8 +153,8 @@ TEST_F(J2ComponentTests, CalculationEquivalenceTest)
 TEST_F(J2ComponentTests, EquilavelnceWIthPreCalculatedTest)
 {
     const int num_debris = 9;
-    std::array<std::array<double, 3>, num_debris> accelerations;
-    std::array<double, 3> acc_total_dummy;
+    std::array<std::array<double, 3>, num_debris> accelerations{};
+    std::array<double, 3> acc_total_dummy{};
 
     // calculate the acceleration for all particles using two different functions
     for (int i = 0; i < num_debris; ++i) {
@@ -179,9 +179,9 @@ TEST_F(J2ComponentTests, EquilavelnceWIthPreCalculatedTest)
 TEST_F(C22ComponentTests, CalculationEquivalenceTest)
 {
     const int num_debris = 12;
-    std::array<std::array<double, 3>, num_debris> accelerations_1;
-    std::array<std::array<double, 3>, num_debris> accelerations_2;
-    std::array<double, 3> acc_total_dummy;
+    std::array<std::array<double, 3>, num_debris> accelerations_1{};
+    std::array<std::array<double, 3>, num_debris> accelerations_2{};
+    std::array<double, 3> acc_total_dummy{};
     double t = 0;
     double c_term = std::cos(Physics::THETA_G + Physics::NU_EARTH * t);
     double s_term = std::sin(Physics::THETA_G + Physics::NU_EARTH * t);
@@ -211,8 +211,8 @@ TEST_F(C22ComponentTests, CalculationEquivalenceTest)
 TEST_F(C22ComponentTests, EquilavelnceWIthPreCalculatedTest)
 {
     const int num_debris = 9;
-    std::array<std::array<double, 3>, num_debris> accelerations;
-    std::array<double, 3> acc_total_dummy;
+    std::array<std::array<double, 3>, num_debris> accelerations{};
+    std::array<double, 3> acc_total_dummy{};
     double t = 0;
     double c_term = std::cos(Physics::THETA_G + Physics::NU_EARTH * t);
     double s_term = std::sin(Physics::THETA_G + Physics::NU_EARTH * t);
@@ -241,9 +241,9 @@ TEST_F(C22ComponentTests, EquilavelnceWIthPreCalculatedTest)
 TEST_F(S22ComponentTests, CalculationEquivalenceTest)
 {
     const int num_debris = 12;
-    std::array<std::array<double, 3>, num_debris> accelerations_1;
-    std::array<std::array<double, 3>, num_debris> accelerations_2;
-    std::array<double, 3> acc_total_dummy;
+    std::array<std::array<double, 3>, num_debris> accelerations_1{};
+    std::array<std::array<double, 3>, num_debris> accelerations_2{};
+    std::array<double, 3> acc_total_dummy{};
     double t = 0;
     double c_term = std::cos(Physics::THETA_G + Physics::NU_EARTH * t);
     double s_term = std::sin(Physics::THETA_G + Physics::NU_EARTH * t);
@@ -273,8 +273,8 @@ TEST_F(S22ComponentTests, CalculationEquivalenceTest)
 TEST_F(S22ComponentTests, EquilavelnceWIthPreCalculatedTest)
 {
     const int num_debris = 9;
-    std::array<std::array<double, 3>, num_debris> accelerations;
-    std::array<double, 3> acc_total_dummy;
+    std::array<std::array<double, 3>, num_debris> accelerations{};
+    std::array<double, 3> acc_total_dummy{};
     double t = 0;
     double c_term = std::cos(Physics::THETA_G + Physics::NU_EARTH * t);
     double s_term = std::sin(Physics::THETA_G + Physics::NU_EARTH * t);
@@ -303,9 +303,9 @@ TEST_F(S22ComponentTests, EquilavelnceWIthPreCalculatedTest)
 TEST_F(LunComponentTests, CalculationEquivalenceTest)
 {
     const int num_debris = 9;
-    std::array<std::array<double, 3>, num_debris> accelerations_1;
-    std::array<std::array<double, 3>, num_debris> accelerations_2;
-    std::array<double, 3> acc_total_dummy;
+    std::array<std::array<double, 3>, num_debris> accelerations_1{};
+    std::array<std::array<double, 3>, num_debris> accelerations_2{};
+    std::array<double, 3> acc_total_dummy{};
     double t = 1;
 
     // test for different t values
@@ -338,8 +338,8 @@ TEST_F(LunComponentTests, CalculationEquivalenceTest)
 TEST_F(LunComponentTests, EquilavelnceWIthPreCalculatedTest)
 {
     const int num_debris = 9;
-    std::array<std::array<double, 3>, num_debris> accelerations;
-    std::array<double, 3> acc_total_dummy;
+    std::array<std::array<double, 3>, num_debris> accelerations{};
+    std::array<double, 3> acc_total_dummy{};
     double t = 0;
     std::array<double, 6> moon_params = Acceleration::LunComponent::setUp(t);
 
@@ -537,7 +537,7 @@ TEST_F(LunComponentTests, CompareTrigonometricTerms)
     ASSERT_NEAR(std::sin((f_m + lambda1 - l_0 + (412.0 / 3600) * s_2fm + (541.0 / 3600) * s_l1m) * M_PIf64 / 180),
         std::sin((f_m + lambda2 - l_0 + (412.0 / 3600) * std::sin((2 * f_m) * M_PIf64 / 180) + (541.0 / 3600) * std::sin((l1_m)*M_PIf64 / 180)) * M_PIf64 / 180),
         abs_err);
-    ;
+
     ASSERT_NEAR(s_fm * c_2dm - c_fm * s_2dm,
         std::sin((f_m - 2 * d_m) * M_PIf64 / 180), abs_err);
     ASSERT_NEAR(
@@ -566,9 +566,9 @@ TEST_F(LunComponentTests, CompareTrigonometricTerms)
 TEST_F(SolComponentTests, CalculationEquivalenceTest)
 {
     const int num_debris = 9;
-    std::array<std::array<double, 3>, num_debris> accelerations_1;
-    std::array<std::array<double, 3>, num_debris> accelerations_2;
-    std::array<double, 3> acc_total_dummy;
+    std::array<std::array<double, 3>, num_debris> accelerations_1{};
+    std::array<std::array<double, 3>, num_debris> accelerations_2{};
+    std::array<double, 3> acc_total_dummy{};
     double t = 0.1;
     double d_ref;
     for (int j = 0; j < 10; ++j) {
@@ -601,8 +601,8 @@ TEST_F(SolComponentTests, CalculationEquivalenceTest)
 TEST_F(SolComponentTests, EquilavelnceWIthPreCalculatedTest)
 {
     const int num_debris = 9;
-    std::array<std::array<double, 3>, num_debris> accelerations;
-    std::array<double, 3> acc_total_dummy;
+    std::array<std::array<double, 3>, num_debris> accelerations{};
+    std::array<double, 3> acc_total_dummy{};
 
     // calculate the acceleration for all particles using two different functions
     for (int i = 0; i < num_debris; ++i) {
@@ -647,9 +647,9 @@ TEST_F(SolComponentTests, CompareSetupFunction)
 TEST_F(SolComponentTests, CompareAfterSetupCalculations)
 {
     const int num_debris = 9;
-    std::array<std::array<double, 3>, num_debris> accelerations_1;
-    std::array<std::array<double, 3>, num_debris> accelerations_2;
-    std::array<double, 3> acc_total_dummy;
+    std::array<std::array<double, 3>, num_debris> accelerations_1{};
+    std::array<std::array<double, 3>, num_debris> accelerations_2{};
+    std::array<double, 3> acc_total_dummy{};
     double t = 0.1;
     double d_ref;
     for (int j = 0; j < 10; ++j) {
@@ -683,10 +683,10 @@ TEST_F(SolComponentTests, CompareAfterSetupCalculations)
 TEST_F(C22S22ComponentTests, CalculationEquivalenceTest)
 {
     const int num_debris = 12;
-    std::array<std::array<double, 3>, num_debris> accelerations_1;
-    std::array<std::array<double, 3>, num_debris> accelerations_2;
-    std::array<std::array<double, 3>, num_debris> accelerations_3;
-    std::array<double, 3> acc_total_dummy;
+    std::array<std::array<double, 3>, num_debris> accelerations_1{};
+    std::array<std::array<double, 3>, num_debris> accelerations_2{};
+    std::array<std::array<double, 3>, num_debris> accelerations_3{};
+    std::array<double, 3> acc_total_dummy{};
     double t = 0;
     double c_term = std::cos(Physics::THETA_G + Physics::NU_EARTH * t);
     double s_term = std::sin(Physics::THETA_G + Physics::NU_EARTH * t);
@@ -724,9 +724,9 @@ TEST_F(C22S22ComponentTests, CalculationEquivalenceTest)
 TEST_F(SRPComponentTests, CalculationEquivalenceTest)
 {
     const int num_debris = 9;
-    std::array<std::array<double, 3>, num_debris> accelerations_1;
-    std::array<std::array<double, 3>, num_debris> accelerations_2;
-    std::array<double, 3> acc_total_dummy;
+    std::array<std::array<double, 3>, num_debris> accelerations_1{};
+    std::array<std::array<double, 3>, num_debris> accelerations_2{};
+    std::array<double, 3> acc_total_dummy{};
     double t = 0.1;
     double d_ref = 0;
     for (int j = 0; j < 10; ++j) {
@@ -742,7 +742,7 @@ TEST_F(SRPComponentTests, CalculationEquivalenceTest)
         }
 
         // result is identical
-        double abs_err = 0;
+        double abs_err = 1e-19;
         for (int i = 0; i < debris->getDebrisVector().size(); ++i) {
             EXPECT_NEAR(accelerations_1[i][0], accelerations_2[i][0], abs_err);
             EXPECT_NEAR(accelerations_1[i][1], accelerations_2[i][1], abs_err);
@@ -759,8 +759,8 @@ TEST_F(SRPComponentTests, CalculationEquivalenceTest)
 TEST_F(SRPComponentTests, EquilavelnceWIthPreCalculatedTest)
 {
     const int num_debris = 9;
-    std::array<std::array<double, 3>, num_debris> accelerations;
-    std::array<double, 3> acc_total_dummy;
+    std::array<std::array<double, 3>, num_debris> accelerations{};
+    std::array<double, 3> acc_total_dummy{};
 
     // calculate the acceleration for all particles using two different functions
     for (int i = 0; i < debris->getDebrisVector().size(); ++i) {
@@ -785,9 +785,9 @@ TEST_F(SRPComponentTests, EquilavelnceWIthPreCalculatedTest)
 TEST_F(DragComponentTests, CalculationEquivalenceTest)
 {
     const int num_debris = 12;
-    std::array<std::array<double, 3>, num_debris> accelerations_1;
-    std::array<std::array<double, 3>, num_debris> accelerations_2;
-    std::array<double, 3> acc_total_dummy;
+    std::array<std::array<double, 3>, num_debris> accelerations_1{};
+    std::array<std::array<double, 3>, num_debris> accelerations_2{};
+    std::array<double, 3> acc_total_dummy{};
 
     // calculate the acceleration for all particles using two different functions
     for (int i = 0; i < num_debris; ++i) {
@@ -797,7 +797,7 @@ TEST_F(DragComponentTests, CalculationEquivalenceTest)
     }
 
     // no error
-    double abs_err = 0;
+    double abs_err = 1e-49;
     for (int i = 0; i < num_debris; ++i) {
         EXPECT_NEAR(accelerations_1[i][0], accelerations_2[i][0], abs_err);
         EXPECT_NEAR(accelerations_1[i][1], accelerations_2[i][1], abs_err);
@@ -813,8 +813,8 @@ TEST_F(DragComponentTests, CalculationEquivalenceTest)
 TEST_F(DragComponentTests, EquilavelnceWIthPreCalculatedTest)
 {
     const int num_debris = 9;
-    std::array<std::array<double, 3>, num_debris> accelerations;
-    std::array<double, 3> acc_total_dummy;
+    std::array<std::array<double, 3>, num_debris> accelerations{};
+    std::array<double, 3> acc_total_dummy{};
 
     // calculate the acceleration for all particles using two different functions
     for (int i = 0; i < num_debris; ++i) {

--- a/test/physics_test/Acceleration_test.h
+++ b/test/physics_test/Acceleration_test.h
@@ -652,6 +652,7 @@ protected:
                 std::array<double, 3> pos { 0, 0, 0 };
                 pos[j] = (i + 2) * 3.5e3;
                 d.setPosition(pos);
+                d.setAom(i*j+0.1);
                 debris->addDebris(d);
             }
         }
@@ -719,6 +720,7 @@ protected:
                 std::array<double, 3> pos { 0, 0, 0 };
                 pos[j] = (i + 2) * 3.5e3;
                 d.setPosition(pos);
+                d.setBcInv(i*j+0.1);
                 debris->addDebris(d);
             }
         }
@@ -728,6 +730,7 @@ protected:
             pos[(i + 1) % 3] = 4321;
             pos[(i + 2) % 3] = 3210;
             d.setPosition(pos);
+            d.setBcInv(i+0.1);
             debris->addDebris(d);
         }
     }


### PR DESCRIPTION
- `const` correctness.
- clang-tidy recommendations
- Fixed wrong SRP calculations
  Didn't use `getFactor()` in calculation
- fixed SRP and DRAG tests (use non zero aom and bcinv)
  Set area over mass and inverse ballistic component of test particles if the calculation uses them